### PR TITLE
Make the assertion messages lazy

### DIFF
--- a/src/assertions/checked.js
+++ b/src/assertions/checked.js
@@ -1,7 +1,7 @@
 export default function checked ({ wrapper, markup, sig }) {
   this.assert(
     wrapper.isChecked(),
-    'expected ' + sig + ' to be checked ' + markup,
-    'expected ' + sig + ' not to be checked ' + markup
+    () => 'expected ' + sig + ' to be checked ' + markup(),
+    () => 'expected ' + sig + ' not to be checked ' + markup()
   )
 }

--- a/src/assertions/className.js
+++ b/src/assertions/className.js
@@ -3,8 +3,8 @@ export default function className ({ wrapper, markup, arg1, sig }) {
 
   this.assert(
     wrapper.hasClass(arg1),
-    'expected ' + sig + ' to have a #{exp} class, but it has #{act} ' + markup,
-    'expected ' + sig + ' not to have a #{exp} class, but it has #{act} ' + markup,
+    () => 'expected ' + sig + ' to have a #{exp} class, but it has #{act} ' + markup(),
+    () => 'expected ' + sig + ' not to have a #{exp} class, but it has #{act} ' + markup(),
     arg1,
     actual
   )

--- a/src/assertions/contain.js
+++ b/src/assertions/contain.js
@@ -1,8 +1,8 @@
 export default function contain ({ wrapper, markup, arg1, sig }) {
   this.assert(
     wrapper.hasNode(arg1),
-    'expected ' + sig + ' to contain #{exp} ' + markup,
-    'expected ' + sig + ' not to contain #{exp} ' + markup,
+    () => 'expected ' + sig + ' to contain #{exp} ' + markup(),
+    () => 'expected ' + sig + ' not to contain #{exp} ' + markup(),
     arg1
   )
 }

--- a/src/assertions/descendants.js
+++ b/src/assertions/descendants.js
@@ -1,8 +1,8 @@
 export default function descendants ({ wrapper, markup, arg1, sig }) {
   this.assert(
     wrapper.hasDescendants(arg1),
-    'expected ' + sig + ' to have descendants #{exp} ' + markup,
-    'expected ' + sig + ' not to have descendants #{exp} ' + markup,
+    () => 'expected ' + sig + ' to have descendants #{exp} ' + markup(),
+    () => 'expected ' + sig + ' not to have descendants #{exp} ' + markup(),
     arg1
   )
 }

--- a/src/assertions/disabled.js
+++ b/src/assertions/disabled.js
@@ -1,7 +1,7 @@
 export default function disabled ({ wrapper, markup, sig }) {
   this.assert(
     wrapper.isDisabled(),
-    'expected ' + sig + ' to be disabled ' + markup,
-    'expected ' + sig + ' not to be disabled ' + markup
+    () => 'expected ' + sig + ' to be disabled ' + markup(),
+    () => 'expected ' + sig + ' not to be disabled ' + markup()
   )
 }

--- a/src/assertions/empty.js
+++ b/src/assertions/empty.js
@@ -1,7 +1,7 @@
 export default function empty ({ wrapper, markup, sig }) {
   this.assert(
     wrapper.isEmpty(),
-    'expected ' + sig + ' to be empty ' + markup,
-    'expected ' + sig + ' not to be empty ' + markup
+    () => 'expected ' + sig + ' to be empty ' + markup(),
+    () => 'expected ' + sig + ' not to be empty ' + markup()
   )
 }

--- a/src/assertions/exist.js
+++ b/src/assertions/exist.js
@@ -1,7 +1,7 @@
 export default function exist ({ wrapper, markup, sig }) {
   this.assert(
     wrapper.isPresent(),
-    'expected ' + sig + ' to exist ' + markup,
-    'expected ' + sig + ' not to exist ' + markup
+    () => 'expected ' + sig + ' to exist ' + markup(),
+    () => 'expected ' + sig + ' not to exist ' + markup()
   )
 }

--- a/src/assertions/generic.js
+++ b/src/assertions/generic.js
@@ -5,8 +5,8 @@ export default function generic (assertion, desc) {
     if (!flag(this, 'negate') || undefined === arg2) {
       this.assert(
         undefined !== actual,
-        'expected ' + sig + ' to have a #{exp} ' + desc + markup,
-        'expected ' + sig + ' not to have a #{exp} ' + desc + markup,
+        () => 'expected ' + sig + ' to have a #{exp} ' + desc + markup(),
+        () => 'expected ' + sig + ' not to have a #{exp} ' + desc + markup(),
         arg1
       )
     }
@@ -14,8 +14,8 @@ export default function generic (assertion, desc) {
     if (undefined !== arg2) {
       this.assert(
         arg2 === actual,
-        'expected ' + sig + ' to have a ' + inspect(arg1) + ' ' + desc + ' with the value #{exp}, but the value was #{act}' + markup,
-        'expected ' + sig + ' not to have a ' + inspect(arg1) + ' ' + desc + ' with the value #{act}' + markup,
+        () => 'expected ' + sig + ' to have a ' + inspect(arg1) + ' ' + desc + ' with the value #{exp}, but the value was #{act}' + markup(),
+        () => 'expected ' + sig + ' not to have a ' + inspect(arg1) + ' ' + desc + ' with the value #{act}' + markup(),
         arg2,
         actual
       )

--- a/src/assertions/html.js
+++ b/src/assertions/html.js
@@ -4,8 +4,8 @@ export default function html ({ wrapper, markup, flag, arg1, sig }) {
   if (undefined !== arg1) {
     this.assert(
       actual === arg1,
-      'expected ' + sig + ' to be #{exp}, but it was #{act} ' + markup,
-      'expected ' + sig + ' not to be #{exp}, but it was #{act} ' + markup,
+      () => 'expected ' + sig + ' to be #{exp}, but it was #{act} ' + markup(),
+      () => 'expected ' + sig + ' not to be #{exp}, but it was #{act} ' + markup(),
       arg1,
       actual
     )

--- a/src/assertions/id.js
+++ b/src/assertions/id.js
@@ -3,8 +3,8 @@ export default function id ({ wrapper, markup, arg1, sig }) {
 
   this.assert(
     wrapper.hasId(arg1),
-    'expected ' + sig + ' to have a #{exp} id, but it has #{act} ' + markup,
-    'expected ' + sig + ' not to have a #{exp} id, but it has #{act} ' + markup,
+    () => 'expected ' + sig + ' to have a #{exp} id, but it has #{act} ' + markup(),
+    () => 'expected ' + sig + ' not to have a #{exp} id, but it has #{act} ' + markup(),
     arg1,
     actual
   )

--- a/src/assertions/match.js
+++ b/src/assertions/match.js
@@ -1,8 +1,8 @@
 export default function match ({ wrapper, markup, arg1, sig }) {
   this.assert(
     wrapper.is(arg1),
-    'expected ' + sig + ' to match #{exp} ' + markup,
-    'expected ' + sig + ' not to match #{exp} ' + markup,
+    () => 'expected ' + sig + ' to match #{exp} ' + markup(),
+    () => 'expected ' + sig + ' not to match #{exp} ' + markup(),
     arg1
   )
 }

--- a/src/assertions/ref.js
+++ b/src/assertions/ref.js
@@ -1,8 +1,8 @@
 export default function ref ({ wrapper, markup, arg1, sig }) {
   this.assert(
     wrapper.hasRef(arg1),
-    'expected ' + sig + ' to have a #{exp} ref ' + markup,
-    'expected ' + sig + ' not to have a #{exp} ref ' + markup,
+    () => 'expected ' + sig + ' to have a #{exp} ref ' + markup(),
+    () => 'expected ' + sig + ' not to have a #{exp} ref ' + markup(),
     arg1
   )
 }

--- a/src/assertions/selected.js
+++ b/src/assertions/selected.js
@@ -1,7 +1,7 @@
 export default function selected ({ wrapper, markup, sig }) {
   this.assert(
     wrapper.isSelected(),
-    'expected ' + sig + ' to be selected ' + markup,
-    'expected ' + sig + ' not to be selected ' + markup
+    () => 'expected ' + sig + ' to be selected ' + markup(),
+    () => 'expected ' + sig + ' not to be selected ' + markup()
   )
 }

--- a/src/assertions/tagName.js
+++ b/src/assertions/tagName.js
@@ -3,8 +3,8 @@ export default function tagName ({ wrapper, markup, arg1, sig }) {
 
   this.assert(
     actual === arg1,
-    'expected ' + sig + ' to have a #{exp} tag name, but it has #{act} ' + markup,
-    'expected ' + sig + ' not to have a #{exp} tag name, but it has #{act} ' + markup,
+    () => 'expected ' + sig + ' to have a #{exp} tag name, but it has #{act} ' + markup(),
+    () => 'expected ' + sig + ' not to have a #{exp} tag name, but it has #{act} ' + markup(),
     arg1,
     actual
   )

--- a/src/assertions/text.js
+++ b/src/assertions/text.js
@@ -5,16 +5,16 @@ export default function text ({ wrapper, markup, flag, arg1, sig }) {
     if (flag(this, 'contains')) {
       this.assert(
         actual.includes(String(arg1)),
-        'expected ' + sig + ' to contain text #{exp}, but it has #{act} ' + markup,
-        'expected ' + sig + ' not to contain text #{exp}, but it has #{act} ' + markup,
+        () => 'expected ' + sig + ' to contain text #{exp}, but it has #{act} ' + markup(),
+        () => 'expected ' + sig + ' not to contain text #{exp}, but it has #{act} ' + markup(),
         arg1,
         actual
       )
     } else {
       this.assert(
         actual === String(arg1),
-        'expected ' + sig + ' to have text #{exp}, but it has #{act} ' + markup,
-        'expected ' + sig + ' not to have text #{exp}, but it has #{act} ' + markup,
+        () => 'expected ' + sig + ' to have text #{exp}, but it has #{act} ' + markup(),
+        () => 'expected ' + sig + ' not to have text #{exp}, but it has #{act} ' + markup(),
         arg1,
         actual
       )

--- a/src/assertions/value.js
+++ b/src/assertions/value.js
@@ -3,8 +3,8 @@ export default function value ({ wrapper, markup, arg1, sig }) {
 
   this.assert(
     wrapper.hasValue(arg1),
-    'expected ' + sig + ' to have a #{exp} value, but it has #{act} ' + markup,
-    'expected ' + sig + ' not to have a #{exp} value, but it has #{act} ' + markup,
+    () => 'expected ' + sig + ' to have a #{exp} value, but it has #{act} ' + markup(),
+    () => 'expected ' + sig + ' not to have a #{exp} value, but it has #{act} ' + markup(),
     arg1,
     actual
   )

--- a/src/debug.js
+++ b/src/debug.js
@@ -5,7 +5,13 @@ function indent (n) {
 }
 
 export default function debug (wrapper) {
-  const html = prettyPrint(wrapper.html(), { indent_size: 2 })
+  let html = null
+
+  try {
+    html = prettyPrint(wrapper.html(), { indent_size: 2 })
+  } catch (err) {
+    return `HTML: Not available due to: ${err.message}`
+  }
 
   const out = `\n\nHTML:\n\n${html}`
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default function (debug = printDebug) {
         }
 
         assertion.call(this, {
-          markup: debug(wrapper),
+          markup: () => debug(wrapper),
           sig: inspect(wrapper),
           wrapper,
           arg1,


### PR DESCRIPTION
Make the assertion messages and the markup compilation lazy. Also, in some cases, the components under test might not be able to return an output, since some of their subcomponents do not render properly (when doing shallow rendering).

The issue was originally reported by @andreasklinger 

cc @ayrton @andreasklinger 