### PR TITLE
Don't create el in constructor for shallow

### DIFF
--- a/src/ShallowTestWrapper.js
+++ b/src/ShallowTestWrapper.js
@@ -6,7 +6,14 @@ export default class ShallowTestWrapper extends TestWrapper {
   constructor (wrapper) {
     super()
     this.wrapper = wrapper
-    this.el = $(wrapper.html())
+  }
+
+  get el () {
+    if (!this.__el) {
+      this.__el = $(this.wrapper.html())
+    }
+
+    return this.__el
   }
 
   inspect () {


### PR DESCRIPTION
Hi.

I like to use chai-shortcuts for enzyme, but it brakes the best feature about shallow rendering.
React shallow renders only one level of component, and all nested components are mocked by default.
It's very useful because I can don't care about children components in my tests.
But chai-enzyme creates `this.el` in constructor, underhood it call React.renderToString that renders all tree and my tests are broken because I don't pass all dependences in context. (component that I test don't need them, only children)

Do you mind to make create `this.el` in lazy way?