### PR TITLE
Only overwriteAssert if already exists fixes #11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,30 +71,56 @@ export default function (debug = printDebug) {
       })
     }
 
-    overwriteMethod(generic('attr', 'attribute'), 'attr')
-    overwriteMethod(generic('data', 'data attribute'), 'data')
-    overwriteMethod(generic('style', 'CSS style property'), 'style')
-    overwriteMethod(generic('state', 'state'), 'state')
-    overwriteMethod(generic('prop', 'prop'), 'prop')
+    function addMethod (assertion, name) {
+      name = name || assertion.name
 
-    overwriteMethod(checked)
-    overwriteMethod(className)
-    overwriteMethod(disabled)
-    overwriteMethod(id)
-    overwriteMethod(selected)
-    overwriteMethod(value)
-    overwriteMethod(match)
-    overwriteMethod(descendants)
-    overwriteMethod(ref)
-    overwriteMethod(html)
-    overwriteMethod(tagName)
-    overwriteMethod(text)
+      Assertion.addMethod(name, function (arg1, arg2) {
+        const wrapper = wrap(flag(this, 'object'))
+        assertion.call(this, {
+          markup: () => debug(wrapper),
+          sig: inspect(wrapper),
+          wrapper,
+          arg1,
+          arg2,
+          flag,
+          inspect
+        })
+      })
+    }
+
+    function addAssertion (assertion, name) {
+      name = name || assertion.name
+      if(chai.Assertion.prototype[name]) {
+        overwriteMethod (assertion, name)
+      } else {
+        addMethod (assertion, name)
+      }
+    }
+
+    addAssertion(generic('attr', 'attribute'), 'attr')
+    addAssertion(generic('data', 'data attribute'), 'data')
+    addAssertion(generic('style', 'CSS style property'), 'style')
+    addAssertion(generic('state', 'state'), 'state')
+    addAssertion(generic('prop', 'prop'), 'prop')
+
+    addAssertion(checked)
+    addAssertion(className)
+    addAssertion(disabled)
+    addAssertion(id)
+    addAssertion(selected)
+    addAssertion(value)
+    addAssertion(match)
+    addAssertion(descendants)
+    addAssertion(ref)
+    addAssertion(html)
+    addAssertion(tagName)
+    addAssertion(text)
 
     overwriteProperty(empty)
-    overwriteMethod(empty, 'blank')
+    addAssertion(empty, 'blank')
 
     overwriteProperty(exist)
-    overwriteMethod(exist, 'present')
+    addAssertion(exist, 'present')
 
     overwriteChainableMethod(contain)
   }

--- a/test/attr.test.js
+++ b/test/attr.test.js
@@ -11,6 +11,16 @@ class Fixture extends React.Component {
 const it = createTest(<Fixture />)
 
 describe('#attr', () => {
+  it('fails when actual is not a enzymeWrapper', () => {
+    expect(() => {
+      expect(undefined).to.have.attr('key', 'somekey')
+      expect({ 'foo': 'bar' }).to.have.attr('key', 'somekey')
+      expect([]).to.have.attr('key', 'somekey')
+      expect('test').to.have.attr('key', 'somekey')
+      expect(12345).to.have.attr('key', 'somekey')
+    }).to.throw()
+  })
+
   describe('(attr)', () => {
     it('passes when the actual matches the expected', (wrapper) => {
       expect(wrapper.find('span')).to.have.attr('id')

--- a/test/blank.test.js
+++ b/test/blank.test.js
@@ -30,5 +30,11 @@ describe('#blank', () => {
         expect(wrapper.find('#parent')).to.be.blank()
       }).to.throw(`to be empty`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.be.blank()
+      }).to.throw()
+    })
   })
 })

--- a/test/checked.test.js
+++ b/test/checked.test.js
@@ -30,5 +30,11 @@ describe('#checked', () => {
         expect(wrapper.find('#checked')).to.not.be.checked()
       }).to.throw(`not to be checked`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.be.checked()
+      }).to.throw()
+    })
   })
 })

--- a/test/className.test.js
+++ b/test/className.test.js
@@ -39,5 +39,11 @@ describe('#className', () => {
         expect(wrapper.find('span')).to.not.have.className('child')
       }).to.throw(`not to have a 'child' class`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.className('child')
+      }).to.throw()
+    })
   })
 })

--- a/test/contain.test.js
+++ b/test/contain.test.js
@@ -27,11 +27,11 @@ const it = createTest(<Fixture />)
 
 describe('#contain', () => {
   describe('(node)', () => {
+
     it('passes when the actual matches the expected', (wrapper) => {
       expect(wrapper).to.contain(<User index={1} />)
       expect(wrapper).to.contain(<User index={2} />)
     }, { render: false })
-
     it('passes negated when the actual does not match the expected', (wrapper) => {
       expect(wrapper).to.not.contain(<User index={3} />)
     }, { render: false })
@@ -45,5 +45,11 @@ describe('#contain', () => {
         expect(wrapper).to.not.contain(<User index={2} />)
       }).to.throw(`not to contain`)
     }, { render: false })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.contain(<User index={1} />)
+      }).to.throw()
+    })
   })
 })

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -39,6 +39,12 @@ describe('#data', () => {
         expect(wrapper.find('span')).to.not.have.data('name')
       }).to.throw(`not to have a 'name' data attribute`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.data('name')
+      }).to.throw()
+    })
   })
 
   describe('(attr, value)', () => {

--- a/test/descendants.test.js
+++ b/test/descendants.test.js
@@ -41,5 +41,11 @@ describe('#descendants', () => {
         expect(wrapper.find('#child')).to.not.have.descendants('#last')
       }).to.throw(`not to have descendants '#last'`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.descendants('#root')
+      }).to.throw()
+    })
   })
 })

--- a/test/disabled.test.js
+++ b/test/disabled.test.js
@@ -30,5 +30,11 @@ describe('#disabled', () => {
         expect(wrapper.find('#disabled')).to.not.be.disabled()
       }).to.throw(`not to be disabled`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.be.disabled()
+      }).to.throw()
+    })
   })
 })

--- a/test/exist.test.js
+++ b/test/exist.test.js
@@ -19,5 +19,11 @@ describe('#exist', () => {
         expect(wrapper.find('#parent')).to.not.exist
       }).to.throw(`not to exist`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.exist
+      }).to.throw()
+    })
   })
 })

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -30,6 +30,12 @@ describe('#html', () => {
       }).to.throw(`not to be '<span id`)
     })
 
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.html('<span id="child">Test</span>')
+      }).to.throw()
+    })
+
     it('chains', (wrapper) => {
       expect(wrapper.find('#child')).to.have.html().match(/Test/)
     })

--- a/test/id.test.js
+++ b/test/id.test.js
@@ -39,5 +39,11 @@ describe('#id', () => {
         expect(wrapper.find('span')).to.not.have.id('child')
       }).to.throw(`not to have a 'child' id`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.id('child')
+      }).to.throw()
+    })
   })
 })

--- a/test/present.test.js
+++ b/test/present.test.js
@@ -19,5 +19,11 @@ describe('#present', () => {
         expect(wrapper.find('#parent')).to.not.be.present()
       }).to.throw(`not to exist`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.be.present()
+      }).to.throw()
+    })
   })
 })

--- a/test/prop.test.js
+++ b/test/prop.test.js
@@ -64,6 +64,12 @@ describe('#prop', () => {
         expect(wrapper.find(User).first()).to.not.have.prop('index', 1)
       }).to.throw(`not to have a 'index' prop with the value 1`)
     }, { render: false })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.prop('index')
+      }).to.throw()
+    })
   })
 
   it('chains', (wrapper) => {

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -29,5 +29,11 @@ describe('#ref', () => {
         expect(wrapper).to.not.have.ref('test')
       }).to.throw(`not to have a 'test' ref`)
     }, { render: false, shallow: false })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.ref('test')
+      }).to.throw()
+    })
   })
 })

--- a/test/selected.test.js
+++ b/test/selected.test.js
@@ -30,5 +30,11 @@ describe('#selected', () => {
         expect(wrapper.find('#test1')).to.not.be.selected()
       }).to.throw(`not to be selected`)
     }, { shallow: false })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.be.selected()
+      }).to.throw()
+    })
   })
 })

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -58,4 +58,10 @@ describe('#state', () => {
   it('chains', (wrapper) => {
     expect(wrapper).to.have.state('foo').equal('bar')
   }, { render: false })
+
+  it('fails when actual is undefined', () => {
+    expect(() => {
+      expect(undefined).to.have.state('foo')
+    }).to.throw()
+  })
 })

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -39,6 +39,12 @@ describe('#style', () => {
         expect(wrapper.find('span')).to.not.have.style('color')
       }).to.throw(`not to have a 'color' CSS style property`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.style('border')
+      }).to.throw()
+    })
   })
 
   describe('(name, value)', () => {

--- a/test/tagName.test.js
+++ b/test/tagName.test.js
@@ -31,5 +31,11 @@ describe('#tagName', () => {
         expect(wrapper.find('span')).to.have.tagName('a')
       }).to.throw(`to have a 'a' tag name, but it has 'span'`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.tagName('div')
+      }).to.throw()
+    })
   })
 })

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -40,5 +40,11 @@ describe('#text', () => {
       expect(wrapper.find('#child')).to.not.contain.text('other')
       expect(wrapper.find('#child')).to.not.include.text('other')
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.text('Test')
+      }).to.throw()
+    })
   })
 })

--- a/test/value.test.js
+++ b/test/value.test.js
@@ -29,5 +29,11 @@ describe('#value', () => {
         expect(wrapper.find('input')).to.not.have.value('test')
       }).to.throw(`not to have a 'test' value`)
     })
+
+    it('fails when actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.value('test')
+      }).to.throw()
+    })
   })
 })


### PR DESCRIPTION
As discussed in #11 added a check for the assertion on the prototype.
If it doesn't exists use addMethod instead of overwriteMethod