### PR TITLE
Added exactly for asserting the amount of descendants

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -246,6 +246,37 @@ expect(wrapper.find('#child')).to.have.descendants('#last')
 expect(wrapper).to.not.have.descendants('#root1')
 ```
 
+#### `exactly()`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| yes    | yes   | yes     |
+
+
+Assert that the wrapper contains a exact amount of descendants matching the given selector:
+
+```js
+import React from 'react'
+import {mount, render, shallow} from 'enzyme'
+
+class Fixture extends React.Component {
+  render () {
+    return (
+      <div id='root'>
+        <span id='child'>
+          <span class='item'></span>
+          <span class='item'></span>
+        </span>
+      </div>
+    )
+  }
+}
+
+const wrapper = mount(<Fixture />) // mount/render/shallow when applicable
+
+expect(wrapper).to.have.exactly(2).descendants('.item')
+```
+
 #### `disabled()`
 
 | render | mount | shallow |

--- a/src/ChaiWrapper.js
+++ b/src/ChaiWrapper.js
@@ -1,0 +1,170 @@
+import wrap from './wrap'
+
+export default class ChaiWrapper {
+  /**
+   * Constructs a instance of the chai wrapper
+   *
+   * @param chai the instance of chai to wrap around
+   * @param utils the instance of the utils
+   * @param debug the debug method
+     */
+  constructor (chai, utils, debug) {
+    this.chai = chai
+    this.Assertion = chai.Assertion
+    this.utils = utils
+    this.debug = debug
+  }
+
+  /**
+   * Adds or overwrites a assertion method
+   *
+   * @param assertion the assertion to add
+   * @param name the name of the assertion to add
+     */
+  addAssertion (assertion, name) {
+    name = name || assertion.name
+    if (this.chai.Assertion.prototype[name]) {
+      this._overwriteMethod(assertion, name)
+    } else {
+      this._addMethod(assertion, name)
+    }
+  }
+
+  /**
+   * Adds a chainable method
+   *
+   * @param assertion the assertion to add
+   * @param [name] the name of the assertion to add
+   */
+  addChainableMethod (assertion, name) {
+    name = name || assertion.name
+
+    this.Assertion.addChainableMethod(name, this._wrapAssertion(assertion, this))
+  }
+
+  /**
+   * Overwrites a assertion property
+   *
+   * @param assertion the assertion with which to overwrite the existing assertion
+   * @param [name] the name of the assertion to overwrite
+   */
+  overwriteProperty (assertion, name) {
+    name = name || assertion.name
+    const _wrapOverwriteAssertion = this._wrapOverwriteAssertion
+    const chaiWrapper = this
+
+    this.Assertion.overwriteProperty(name, function (_super) {
+      return _wrapOverwriteAssertion(assertion, _super, chaiWrapper)
+    })
+  }
+
+  /**
+   * Overwrites a chainable assertion method, but NOT the chainingBehaviour
+   * ChainingBehaviour calls any pre-existing method.
+   *
+   * @param assertion the assertion with which to overwrite the existing assertion
+   * @param [name] the name of the assertion to overwrite
+   */
+  overwriteChainableMethod (assertion, name) {
+    name = name || assertion.name
+
+    const _wrapOverwriteAssertion = this._wrapOverwriteAssertion
+    const chaiWrapper = this
+
+    this.Assertion.overwriteChainableMethod(name, function (_super) {
+      return _wrapOverwriteAssertion(assertion, _super, chaiWrapper)
+    }, function (_super) {
+      return function () {
+        _super.call(this)
+      }
+    })
+  }
+
+  /*
+   * Wraps the given assertion with a function passing in all the required chai elements
+   *
+   * @param assertion the assertion to wrap
+   * @param _super the super as passed to the chai assertion
+   * @param chaiWrapper the instance of the chaiWrapper
+   * @returns {Function}
+   * @private
+   */
+  _wrapOverwriteAssertion (assertion, _super, chaiWrapper) {
+    const {flag, inspect} = chaiWrapper.utils
+    const debug = chaiWrapper.debug
+
+    return function (arg1, arg2) {
+      const wrapper = wrap(flag(this, 'object'))
+
+      if (!wrapper) {
+        return _super.apply(this, arguments)
+      }
+
+      assertion.call(this, {
+        markup: () => debug(wrapper),
+        sig: inspect(wrapper),
+        wrapper,
+        arg1,
+        arg2,
+        flag,
+        inspect
+      })
+    }
+  }
+
+  /**
+   * Wraps and overwrites a chai assertion method
+   *
+   * @param assertion The new assertion to overwrite the existing with
+   * @param [name] the name of the assertion
+   * @private
+   */
+  _overwriteMethod (assertion, name) {
+    name = name || assertion.name
+    const _wrapOverwriteAssertion = this._wrapOverwriteAssertion
+    const chaiWrapper = this
+
+    this.Assertion.overwriteMethod(name, function (_super) {
+      return _wrapOverwriteAssertion(assertion, _super, chaiWrapper)
+    })
+  }
+
+  /**
+   * Wraps the given assertion with a function passing in all the required chai elements
+   *
+   * @param assertion the assertion to wrap
+   * @param chaiWrapper the instance of the chai wrapper
+   * @returns {Function}
+   * @private
+   */
+  _wrapAssertion (assertion, chaiWrapper) {
+    const {flag, inspect} = chaiWrapper.utils
+    const debug = chaiWrapper.debug
+
+    return function (arg1, arg2) {
+      const wrapper = wrap(flag(this, 'object'))
+      assertion.call(this, {
+        markup: () => debug(wrapper),
+        sig: inspect(wrapper),
+        wrapper,
+        arg1,
+        arg2,
+        flag,
+        inspect
+      })
+    }
+  }
+
+  /**
+   * Wraps then adds the given assertion
+   *
+   * @param assertion The assertion to add
+   * @param [name] the name of the assertion
+   * @private
+   */
+  _addMethod (assertion, name) {
+    name = name || assertion.name
+
+    this.Assertion.addMethod(name, this._wrapAssertion(assertion, this))
+  }
+}

--- a/src/TestWrapper.js
+++ b/src/TestWrapper.js
@@ -16,7 +16,11 @@ export default class TestWrapper {
   }
 
   hasDescendants (selector) {
-    return this.wrapper.find(selector).length > 0
+    return this.getDescendantsCount(selector) > 0
+  }
+
+  getDescendantsCount (selector) {
+    return this.wrapper.find(selector).length
   }
 
   state (key) {

--- a/src/assertions/descendants.js
+++ b/src/assertions/descendants.js
@@ -1,8 +1,21 @@
-export default function descendants ({ wrapper, markup, arg1, sig }) {
-  this.assert(
-    wrapper.hasDescendants(arg1),
-    () => 'expected ' + sig + ' to have descendants #{exp} ' + markup(),
-    () => 'expected ' + sig + ' not to have descendants #{exp} ' + markup(),
-    arg1
-  )
+export default function descendants ({ wrapper, markup, arg1, sig, flag }) {
+  const exactlyCount = flag(this, 'exactlyCount')
+
+  if (exactlyCount) {
+    const descendantCount = wrapper.getDescendantsCount(arg1)
+
+    this.assert(
+        descendantCount === exactlyCount,
+        () => 'expected ' + sig + ' to have ' + exactlyCount + ' descendants #{exp} but actually found ' + descendantCount + markup(),
+        () => 'expected ' + sig + ' not to have ' + exactlyCount + ' descendants #{exp} but actually found ' + descendantCount + markup(),
+        arg1
+    )
+  } else {
+    this.assert(
+        wrapper.hasDescendants(arg1),
+        () => 'expected ' + sig + ' to have descendants #{exp} ' + markup(),
+        () => 'expected ' + sig + ' not to have descendants #{exp} ' + markup(),
+        arg1
+    )
+  }
 }

--- a/src/chains/exactly.js
+++ b/src/chains/exactly.js
@@ -1,0 +1,3 @@
+export default function exactly ({ flag, arg1 }) {
+  flag(this, 'exactlyCount', arg1)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import wrap from './wrap'
 import printDebug from './debug'
 
 import checked from './assertions/checked'
@@ -18,123 +17,39 @@ import tagName from './assertions/tagName'
 import text from './assertions/text'
 import value from './assertions/value'
 import exactly from './chains/exactly'
+import ChaiWrapper from './ChaiWrapper'
 
 export default function (debug = printDebug) {
   return function (chai, utils) {
-    const Assertion = chai.Assertion
-    const {flag, inspect} = utils
+    const chaiWrapper = new ChaiWrapper(chai, utils, debug)
 
-    function wrapOverwriteAssertion (assertion, _super) {
-      return function (arg1, arg2) {
-        const wrapper = wrap(flag(this, 'object'))
+    chaiWrapper.addAssertion(generic('attr', 'attribute'), 'attr')
+    chaiWrapper.addAssertion(generic('data', 'data attribute'), 'data')
+    chaiWrapper.addAssertion(generic('style', 'CSS style property'), 'style')
+    chaiWrapper.addAssertion(generic('state', 'state'), 'state')
+    chaiWrapper.addAssertion(generic('prop', 'prop'), 'prop')
 
-        if (!wrapper) {
-          return _super.apply(this, arguments)
-        }
+    chaiWrapper.addAssertion(checked)
+    chaiWrapper.addAssertion(className)
+    chaiWrapper.addAssertion(disabled)
+    chaiWrapper.addAssertion(id)
+    chaiWrapper.addAssertion(selected)
+    chaiWrapper.addAssertion(value)
+    chaiWrapper.addAssertion(match)
+    chaiWrapper.addAssertion(descendants)
+    chaiWrapper.addAssertion(ref)
+    chaiWrapper.addAssertion(html)
+    chaiWrapper.addAssertion(tagName)
+    chaiWrapper.addAssertion(text)
 
-        assertion.call(this, {
-          markup: () => debug(wrapper),
-          sig: inspect(wrapper),
-          wrapper,
-          arg1,
-          arg2,
-          flag,
-          inspect
-        })
-      }
-    }
+    chaiWrapper.overwriteProperty(empty)
+    chaiWrapper.addAssertion(empty, 'blank')
 
-    function overwriteMethod (assertion, name) {
-      name = name || assertion.name
+    chaiWrapper.overwriteProperty(exist)
+    chaiWrapper.addAssertion(exist, 'present')
 
-      Assertion.overwriteMethod(name, function (_super) {
-        return wrapOverwriteAssertion(assertion, _super)
-      })
-    }
+    chaiWrapper.overwriteChainableMethod(contain)
 
-    function overwriteProperty (assertion, name) {
-      name = name || assertion.name
-
-      Assertion.overwriteProperty(name, function (_super) {
-        return wrapOverwriteAssertion(assertion, _super)
-      })
-    }
-
-    function overwriteChainableMethod (assertion, name) {
-      name = name || assertion.name
-
-      Assertion.overwriteChainableMethod(name, function (_super) {
-        return wrapOverwriteAssertion(assertion, _super)
-      }, function (_super) {
-        return function () {
-          _super.call(this)
-        }
-      })
-    }
-
-    function wrapAssertion (assertion) {
-      return function (arg1, arg2) {
-        const wrapper = wrap(flag(this, 'object'))
-        assertion.call(this, {
-          markup: () => debug(wrapper),
-          sig: inspect(wrapper),
-          wrapper,
-          arg1,
-          arg2,
-          flag,
-          inspect
-        })
-      }
-    }
-
-    function addMethod (assertion, name) {
-      name = name || assertion.name
-
-      Assertion.addMethod(name, wrapAssertion(assertion))
-    }
-
-    function addAssertion (assertion, name) {
-      name = name || assertion.name
-      if (chai.Assertion.prototype[name]) {
-        overwriteMethod(assertion, name)
-      } else {
-        addMethod(assertion, name)
-      }
-    }
-
-    function addChainableMethod (assertion, name) {
-      name = name || assertion.name
-
-      Assertion.addChainableMethod(name, wrapAssertion(assertion))
-    }
-
-    addAssertion(generic('attr', 'attribute'), 'attr')
-    addAssertion(generic('data', 'data attribute'), 'data')
-    addAssertion(generic('style', 'CSS style property'), 'style')
-    addAssertion(generic('state', 'state'), 'state')
-    addAssertion(generic('prop', 'prop'), 'prop')
-
-    addAssertion(checked)
-    addAssertion(className)
-    addAssertion(disabled)
-    addAssertion(id)
-    addAssertion(selected)
-    addAssertion(value)
-    addAssertion(match)
-    addAssertion(descendants)
-    addAssertion(ref)
-    addAssertion(html)
-    addAssertion(tagName)
-    addAssertion(text)
-
-    overwriteProperty(empty)
-    addAssertion(empty, 'blank')
-
-    overwriteProperty(exist)
-    addAssertion(exist, 'present')
-
-    overwriteChainableMethod(contain)
-
-    addChainableMethod(exactly)
+    chaiWrapper.addChainableMethod(exactly)
   }
 }

--- a/test/exactly.test.js
+++ b/test/exactly.test.js
@@ -1,20 +1,20 @@
 class Fixture extends React.Component {
     render () {
       return (
-            <div id='root'>
-        <div id='child'>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <div className='multiple'></div>
-          <span id='last'></span>
+        <div id='root'>
+          <div id='child'>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <div className='multiple'></div>
+            <span id='last'></span>
+          </div>
         </div>
-            </div>
-        )
+      )
     }
 }
 

--- a/test/exactly.test.js
+++ b/test/exactly.test.js
@@ -1,0 +1,51 @@
+class Fixture extends React.Component {
+    render () {
+      return (
+            <div id='root'>
+        <div id='child'>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <div className='multiple'></div>
+          <span id='last'></span>
+        </div>
+            </div>
+        )
+    }
+}
+
+const it = createTest(<Fixture />)
+
+describe('#exactly', () => {
+  describe('descendants', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper).to.have.descendants('#root')
+      expect(wrapper.find('#child')).to.have.descendants('#last')
+      expect(wrapper).to.not.have.exactly(2).descendants('.multiple')
+      expect(wrapper).to.have.exactly(8).descendants('.multiple')
+    })
+
+    it('passes negated when the actual does not match the expected', (wrapper) => {
+      expect(wrapper).to.not.have.exactly(3).descendants('#root1')
+      expect(wrapper.find('#child')).to.not.have.exactly(5).descendants('#last1')
+    })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper).to.have.exactly(3).descendants('.multiple')
+      }).to.throw(`to have 3 descendants '.multiple'`)
+
+      expect(() => {
+        expect(wrapper.find('#child')).exactly(100).descendants('.multiple')
+      }).to.throw(`to have 100 descendants '.multiple'`)
+
+      expect(() => {
+        expect(wrapper).to.not.have.exactly(8).descendants('.multiple')
+      }).to.throw(`not to have 8 descendants '.multiple'`)
+    })
+  })
+})


### PR DESCRIPTION
Makes it easier to assert that wrapper has a exact amount of a certain descendant. fixes #7.

As a bonus I've moved all the chai helper methods for adding assertions from the ```index.js``` to a seperate file.