### PR TITLE
Improved prop chaining example fixes #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ class Fixture extends React.Component {
     return (
       <div>
         <ul>
-          <li><User index={1} /></li>
+          <li><User index={1} objectProp={{foo: 'bar'}} /></li>
           <li><User index={2} /></li>
         </ul>
       </div>
@@ -768,6 +768,7 @@ expect(wrapper.find(User).first()).to.have.prop('index', 1)
 expect(wrapper.find(User).first()).to.not.have.prop('index', 2)
 
 expect(wrapper.find(User).first()).to.have.prop('index').equal(1)
+expect(wrapper.find(User).first()).to.have.prop('objectProp').deep.equal({foo: 'bar'})
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ class Fixture extends React.Component {
     return (
       <div>
         <ul>
-          <li><User index={1} objectProp={{foo: 'bar'}} /></li>
+          <li><User index={1}  user={{name: 'Jane'}} /></li>
           <li><User index={2} /></li>
         </ul>
       </div>
@@ -768,7 +768,7 @@ expect(wrapper.find(User).first()).to.have.prop('index', 1)
 expect(wrapper.find(User).first()).to.not.have.prop('index', 2)
 
 expect(wrapper.find(User).first()).to.have.prop('index').equal(1)
-expect(wrapper.find(User).first()).to.have.prop('objectProp').deep.equal({foo: 'bar'})
+expect(wrapper.find(User).first()).to.have.prop('user').deep.equal({name: 'Jane'})
 ```
 
 ## Development

--- a/test/prop.test.js
+++ b/test/prop.test.js
@@ -15,7 +15,7 @@ class Fixture extends React.Component {
     return (
       <div>
         <ul>
-          <li><User index={1} /></li>
+          <li><User index={1} objectProp={{foo: 'bar'}} /></li>
           <li><User index={2} /></li>
         </ul>
       </div>
@@ -74,5 +74,6 @@ describe('#prop', () => {
 
   it('chains', (wrapper) => {
     expect(wrapper.find(User).first()).to.have.prop('index').equal(1)
+    expect(wrapper.find(User).first()).to.have.prop('objectProp').deep.equal({foo: 'bar'})
   }, { render: false })
 })


### PR DESCRIPTION
Fixes #10, I might even argue that the second argument of the generic assertions should be removed.
Because that would have made it easier to understand from the beginning.