### PR TITLE
Module export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import tagName from './assertions/tagName'
 import text from './assertions/text'
 import value from './assertions/value'
 
-export default function (debug = printDebug) {
+module.exports = function (debug = printDebug) {
   return function (chai, utils) {
     const Assertion = chai.Assertion
     const {flag, inspect} = utils


### PR DESCRIPTION
People who don't use babel currently have to do:

```js 
var chai-enzyme = require('chai-enzyme').default
// vs.
var chai-enzyme = require('chai-enzyme')
```

As suggested @ljharb in #16:

> Consumers should never have to interact with babel's CommonJS interop