### PR TITLE
Loosen up cheerio dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 ```js
 "peerDependencies": {
+  "cheerio": "^0.19.0",
   "enzyme": "1.x",
   "chai": "3.x"
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@
 
 ```js
 "peerDependencies": {
-  "cheerio": "^0.19.0",
   "enzyme": "1.x",
   "chai": "3.x"
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "test": "npm run test:lint && npm run test:unit"
   },
   "peerDependencies": {
-    "chai": "3.x",
-    "enzyme": "1.x"
+    "cheerio": "^0.19.0",
+    "enzyme": "1.x",
+    "chai": "3.x"
   },
   "keywords": [
     "javascript",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "test": "npm run test:lint && npm run test:unit"
   },
   "peerDependencies": {
-    "cheerio": "^0.19.0",
-    "enzyme": "1.x",
-    "chai": "3.x"
+    "chai": "3.x",
+    "cheerio": "^0.19.0 || ^0.20.0",
+    "enzyme": "1.x"
   },
   "keywords": [
     "javascript",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
     "test": "npm run test:lint && npm run test:unit"
   },
   "peerDependencies": {
-    "cheerio": "^0.19.0",
-    "enzyme": "1.x",
-    "chai": "3.x"
+    "chai": "3.x",
+    "enzyme": "1.x"
   },
   "keywords": [
     "javascript",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "chai": "3.x",
-    "cheerio": "^0.19.0 || ^0.20.0",
+    "cheerio": "0.19.x || 0.20.x",
     "enzyme": "1.x"
   },
   "keywords": [


### PR DESCRIPTION
Loosen up the cheerio dependency, since enzyme 1.5.0 now requires cheerio `^0.20.0` . /cc @lelandrichardson  [Fixes #28] [Closes #25]

Initially I tried removing the dependency, but we're requiring it in our codebase. (😓)