### PR TITLE
.not.exist interaction fixes #37

### DIFF
--- a/src/CheerioTestWrapper.js
+++ b/src/CheerioTestWrapper.js
@@ -4,12 +4,18 @@ export default class CheerioTestWrapper extends TestWrapper {
   constructor (wrapper) {
     super()
     this.wrapper = wrapper
+  }
 
-    if (wrapper.first()['0'].type === 'root') {
-      this.el = wrapper.children().first()
-    } else {
-      this.el = wrapper.first()
+  get el () {
+    if (!this.__el) {
+      if (this.wrapper.first()['0'].type === 'root') {
+        this.__el = this.wrapper.children().first()
+      } else {
+        this.__el = this.wrapper.first()
+      }
     }
+
+    return this.__el
   }
 
   inspect () {

--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -6,7 +6,14 @@ export default class ReactTestWrapper extends TestWrapper {
   constructor (wrapper) {
     super()
     this.wrapper = wrapper
-    this.el = this.wrapper.single((n) => findDOMNode(n))
+  }
+
+  get el () {
+    if (!this.__el) {
+      this.__el = this.wrapper.single((n) => findDOMNode(n))
+    }
+
+    return this.__el
   }
 
   inspect () {

--- a/test/exist.test.js
+++ b/test/exist.test.js
@@ -27,3 +27,21 @@ describe('#exist', () => {
     })
   })
 })
+
+describe('not#exist', () => {
+  describe('()', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper.find('#notfound')).to.not.exist
+    })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper.find('#notfound')).to.exist
+      }).to.throw('to exist')
+    })
+
+    it('passes when the actual is undefined', () => {
+      expect(undefined).to.not.exist
+    })
+  })
+})


### PR DESCRIPTION
Not sure if you're accepting PRs on this repo (no pressure), but here is a possible fix for #37. The `ShallowTestWrapper` was already using this approach of lazily computing the `el` property, so it seemed like a reasonable approach to take in the other wrappers.