### PR TITLE
Add a note on chai.use

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ npm install chai-enzyme --save-dev
 import chai from 'chai'
 import chaiEnzyme from 'chai-enzyme'
 
-chai.use(chaiEnzyme())
+chai.use(chaiEnzyme()) // Note the invocation at the end
 ```
 
 ## Debug output in assertion exceptions


### PR DESCRIPTION
I got stuck w/ an error `AssertionError: expected { Object (root, unrendered, ...) } to have a property '$$typeof'` because I forgot the parens. Seems like this is not common for other chai plugins I've seen, so it might help someone.