### PR TITLE
fix: add missing name argument

### DIFF
--- a/src/ChaiWrapper.js
+++ b/src/ChaiWrapper.js
@@ -25,8 +25,6 @@ export default class ChaiWrapper {
    */
 
   addAssertion (assertion, name) {
-    name = name || assertion.name
-
     if (this.chai.Assertion.prototype[name]) {
       this._overwriteMethod(assertion, name)
     } else {
@@ -42,8 +40,6 @@ export default class ChaiWrapper {
    */
 
   addChainableMethod (assertion, name) {
-    name = name || assertion.name
-
     this.Assertion.addChainableMethod(name, this._wrapAssertion(assertion, this))
   }
 
@@ -55,8 +51,6 @@ export default class ChaiWrapper {
    */
 
   overwriteProperty (assertion, name) {
-    name = name || assertion.name
-
     const _wrapOverwriteAssertion = this._wrapOverwriteAssertion
     const chaiWrapper = this
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,27 +29,27 @@ module.exports = function (debug = printDebug) {
     chaiWrapper.addAssertion(generic('state', 'state'), 'state')
     chaiWrapper.addAssertion(generic('prop', 'prop'), 'prop')
 
-    chaiWrapper.addAssertion(checked)
-    chaiWrapper.addAssertion(className)
-    chaiWrapper.addAssertion(disabled)
-    chaiWrapper.addAssertion(id)
-    chaiWrapper.addAssertion(selected)
-    chaiWrapper.addAssertion(value)
-    chaiWrapper.addAssertion(match)
-    chaiWrapper.addAssertion(descendants)
-    chaiWrapper.addAssertion(ref)
-    chaiWrapper.addAssertion(html)
-    chaiWrapper.addAssertion(tagName)
-    chaiWrapper.addAssertion(text)
+    chaiWrapper.addAssertion(checked, 'checked')
+    chaiWrapper.addAssertion(className, 'className')
+    chaiWrapper.addAssertion(disabled, 'disabled')
+    chaiWrapper.addAssertion(id, 'id')
+    chaiWrapper.addAssertion(selected, 'selected')
+    chaiWrapper.addAssertion(value, 'value')
+    chaiWrapper.addAssertion(match, 'match')
+    chaiWrapper.addAssertion(descendants, 'descendants')
+    chaiWrapper.addAssertion(ref, 'ref')
+    chaiWrapper.addAssertion(html, 'html')
+    chaiWrapper.addAssertion(tagName, 'tagName')
+    chaiWrapper.addAssertion(text, 'text')
 
-    chaiWrapper.overwriteProperty(empty)
+    chaiWrapper.overwriteProperty(empty, 'empty')
     chaiWrapper.addAssertion(empty, 'blank')
 
-    chaiWrapper.overwriteProperty(exist)
+    chaiWrapper.overwriteProperty(exist, 'exist')
     chaiWrapper.addAssertion(exist, 'present')
 
-    chaiWrapper.overwriteChainableMethod(contain)
+    chaiWrapper.overwriteChainableMethod(contain, 'contain')
 
-    chaiWrapper.addChainableMethod(exactly)
+    chaiWrapper.addChainableMethod(exactly, 'exactly')
   }
 }


### PR DESCRIPTION
This fixes a bug in IE, due to the fact that `function.name` is [not supported in IE](http://stackoverflow.com/questions/6903762/function-name-not-supported-in-ie).

This makes `chainableBehavior = undefined` and consequently breaks the code, as shown in the picture.

<img width="592" alt="screen shot 2016-04-07 at 15 27 22" src="https://cloud.githubusercontent.com/assets/2387240/14354460/4961218e-fcd5-11e5-9204-3ae1d641bb73.png">

This PR is a collaboration with @keithamus.