### PR TITLE
Added assertion for props()

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
     1. [`style(key, [val])`](#stylekey-val)
     1. [`state(key, [val])`](#statekey-val)
     1. [`prop(key, [val])`](#propkey-val)
+    1. [`props(key, [val])`](#propskey-val)
   1. [Development](#development)
   1. [Contributing](#contributing)
   1. [License](#license)
@@ -822,6 +823,55 @@ expect(wrapper.find(User).first()).to.not.have.prop('index', 2)
 
 expect(wrapper.find(User).first()).to.have.prop('index').equal(1)
 expect(wrapper.find(User).first()).to.have.prop('user').deep.equal({name: 'Jane'})
+```
+
+#### `props(key, [val])`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | yes   | yes     |
+
+Assert that the wrapper has given set of props [with values]:
+
+```js
+import React from 'react'
+import {mount, render, shallow} from 'enzyme'
+
+class User extends React.Component {
+  render () {
+    return (
+      <span>User {this.props.index}</span>
+    )
+  }
+}
+
+User.propTypes = {
+  index: React.PropTypes.number.isRequired
+}
+
+class Fixture extends React.Component {
+  render () {
+    return (
+      <div>
+        <ul>
+          <li><User index={1}  user={{name: 'Jane'}} /></li>
+          <li><User index={2} /></li>
+        </ul>
+      </div>
+    )
+  }
+}
+
+const wrapper = mount(<Fixture />) // mount/render/shallow when applicable
+
+expect(wrapper.find(User).first()).to.have.props([ 'index', 'user' ])
+expect(wrapper.find(User).first()).to.not.have.props([ 'invalid' ])
+
+
+expect(wrapper.find(User).first()).to.have.props({ index: 1 })
+expect(wrapper.find(User).first()).to.not.have.props({ index: 2 })
+
+expect(wrapper.find(User).first()).to.have.props([ 'index', 'user' ]).deep.equal([ 1, { name: 'Jane' } ])
 ```
 
 ## Development

--- a/src/TestWrapper.js
+++ b/src/TestWrapper.js
@@ -31,6 +31,10 @@ export default class TestWrapper {
     return this.wrapper.prop(key)
   }
 
+  props () {
+    return this.wrapper.props()
+  }
+
   text () {
     return this.wrapper.text()
   }

--- a/src/assertions/props.js
+++ b/src/assertions/props.js
@@ -11,9 +11,9 @@ export default function ref ({ wrapper, markup, flag, arg1, sig }) {
     )
     flag(this, 'object', arg1.map((key) => actual[key]))
   } else {
-    const actualProps = Object.keys(arg1).reduce((copy, key) => {
-      copy[key] = actual[key]
-      return copy
+    const actualProps = Object.keys(arg1).reduce((props, key) => {
+      props[key] = actual[key]
+      return props
     }, {})
     this.assert(
       Object.keys(arg1).every((key) => actualProps[key] === arg1[key]),

--- a/src/assertions/props.js
+++ b/src/assertions/props.js
@@ -1,0 +1,27 @@
+export default function ref ({ wrapper, markup, flag, arg1, sig }) {
+  const actual = wrapper.props()
+
+  if (Array.isArray(arg1)) {
+    this.assert(
+      arg1.every(Object.prototype.hasOwnProperty.bind(actual)),
+      () => 'expected ' + sig + ' to have props #{exp} but props were #{act} ' + markup(),
+      () => 'expected ' + sig + ' not to have props #{exp} but props were #{act} ' + markup(),
+      arg1,
+      Object.keys(actual)
+    )
+    flag(this, 'object', arg1.map((key) => actual[key]))
+  } else {
+    const actualProps = Object.keys(arg1).reduce((copy, key) => {
+      copy[key] = actual[key]
+      return copy
+    }, {})
+    this.assert(
+      Object.keys(arg1).every((key) => actualProps[key] === arg1[key]),
+      () => 'expected ' + sig + ' to have props #{exp} but props were #{act} ' + markup(),
+      () => 'expected ' + sig + ' not to have props #{exp} but props were #{act} ' + markup(),
+      arg1,
+      actualProps
+    )
+    flag(this, 'object', actualProps)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import disabled from './assertions/disabled'
 import empty from './assertions/empty'
 import exist from './assertions/exist'
 import generic from './assertions/generic'
+import props from './assertions/props'
 import html from './assertions/html'
 import id from './assertions/id'
 import match from './assertions/match'
@@ -29,6 +30,7 @@ module.exports = function (debug = printDebug) {
     chaiWrapper.addAssertion(generic('state', 'state'), 'state')
     chaiWrapper.addAssertion(generic('prop', 'prop'), 'prop')
 
+    chaiWrapper.addAssertion(props, 'props')
     chaiWrapper.addAssertion(checked, 'checked')
     chaiWrapper.addAssertion(className, 'className')
     chaiWrapper.addAssertion(disabled, 'disabled')

--- a/test/props.test.js
+++ b/test/props.test.js
@@ -1,0 +1,79 @@
+class User extends React.Component {
+  render () {
+    return (
+      <span>User {this.props.index}</span>
+    )
+  }
+}
+
+User.propTypes = {
+  index: React.PropTypes.number.isRequired
+}
+
+class Fixture extends React.Component {
+  render () {
+    return (
+      <div>
+        <ul>
+          <li><User index={1} objectProp={{foo: 'bar'}} /></li>
+          <li><User index={2} /></li>
+        </ul>
+      </div>
+    )
+  }
+}
+
+const it = createTest(<Fixture />)
+
+describe('#props', () => {
+  describe('([ key, key, key... ])', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper.find(User).first()).to.have.props([ 'index' ])
+    }, { render: false })
+
+    it('passes negated when the actual does not match the expected', (wrapper) => {
+      expect(wrapper.find(User).first()).to.not.have.props([ 'invalid' ])
+    }, { render: false })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper.find(User).first()).to.have.props([ 'invalid' ])
+      }).to.throw("to have props [ 'invalid' ]")
+
+      expect(() => {
+        expect(wrapper.find(User).first()).to.not.have.props([ 'index' ])
+      }).to.throw("not to have props [ 'index' ]")
+    }, { render: false })
+  })
+
+  describe('({ key: value, ... })', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper.find(User).first()).to.have.props({ index: 1 })
+    }, { render: false })
+
+    it('passes negated when the actual does not match the expected', (wrapper) => {
+      expect(wrapper.find(User).first()).to.not.have.props({ index: 2 })
+    }, { render: false })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper.find(User).first()).to.have.props({ index: 2 })
+      }).to.throw('to have props { index: 2 }')
+
+      expect(() => {
+        expect(wrapper.find(User).first()).to.not.have.props({ index: 1 })
+      }).to.throw('not to have props { index: 1 }')
+    }, { render: false })
+
+    it('fails when the actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.props([ 'index' ])
+      }).to.throw()
+    })
+  })
+
+  it('chains', (wrapper) => {
+    expect(wrapper.find(User).first()).to.have.props([ 'index' ]).deep.equal([ 1 ])
+    expect(wrapper.find(User).first()).to.have.props([ 'objectProp' ]).deep.equal([ {foo: 'bar'} ])
+  }, { render: false })
+})

--- a/test/props.test.js
+++ b/test/props.test.js
@@ -73,7 +73,6 @@ describe('#props', () => {
   })
 
   it('chains', (wrapper) => {
-    expect(wrapper.find(User).first()).to.have.props([ 'index' ]).deep.equal([ 1 ])
-    expect(wrapper.find(User).first()).to.have.props([ 'objectProp' ]).deep.equal([ {foo: 'bar'} ])
+    expect(wrapper.find(User).first()).to.have.props([ 'index', 'objectProp' ]).deep.equal([ 1, {foo: 'bar'} ])
   }, { render: false })
 })


### PR DESCRIPTION
Adds an assertion for the presence of props. Supports two styles:
- Keys only: `props([ key, key, key, ... ])`
- Object: `props({ key: value })`

Keys only:

``` jsx
let component = shallow(<a className='example' href='#'>example</a>);
expect(shallow(component)).to.have.props([ 'className', 'href' ]);
```

Using keys also supports chaining assertions onto the result of selected the keys, same as `prop(key)`:

``` jsx
expect(shallow(component)).to.have.props([ 'className', 'href' ]).deep.equal([ 'example', '#' ]);
```

And keys and values:

``` jsx
expect(shallow(component)).to.have.props({ 'className': 'example', 'href': '#' });
```
