### PR TITLE
Fixes attr(a) for an attribute without value

### DIFF
--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -29,7 +29,8 @@ export default class ReactTestWrapper extends TestWrapper {
   }
 
   attr (name) {
-    return this.el.getAttribute(name) || undefined
+    const value = this.el.getAttribute(name)
+    return value !== null ? value : undefined
   }
 
   html () {

--- a/test/attr.test.js
+++ b/test/attr.test.js
@@ -3,6 +3,7 @@ class Fixture extends React.Component {
     return (
       <div id='root'>
         <span id='child'>test</span>
+        <article itemScope>test2</article>
       </div>
     )
   }
@@ -28,6 +29,10 @@ describe('#attr', () => {
     it('passes negated when the actual does not match the expected', (wrapper) => {
       expect(wrapper).to.not.have.attr('disabled')
       expect(wrapper.find('span')).to.not.have.attr('disabled')
+    })
+
+    it('passes when the attribute exists without a value', (wrapper) => {
+      expect(wrapper.find('article')).to.have.attr('itemscope')
     })
 
     it('fails when the actual does not match the expected', (wrapper) => {


### PR DESCRIPTION
Fixes #47 

Instead of returning the attribute value, I kept the `undefined` value when the attribute doesn't exist. Otherwise we''d need to update the generic assertion to also check for the "null" value, and I wasn't comfortable to make this change without breaking the lib for some users (even if all tests passes ;))