### PR TITLE
Add an example of `.descendants` with components

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,20 @@ Assert that the wrapper contains a descendant matching the given selector:
 import React from 'react'
 import {mount, render, shallow} from 'enzyme'
 
+class ChildFixture extends React.Component {
+  render () {
+    return (
+      <span>Fixture</span>
+    )
+  }
+}
+
 class Fixture extends React.Component {
   render () {
     return (
       <div id='root'>
         <span id='child'>
-          <span id='last'></span>
+          <ChildFixture />
         </span>
       </div>
     )
@@ -241,7 +249,7 @@ class Fixture extends React.Component {
 const wrapper = mount(<Fixture />) // mount/render/shallow when applicable
 
 expect(wrapper).to.have.descendants('#root')
-expect(wrapper.find('#child')).to.have.descendants('#last')
+expect(wrapper.find('#child')).to.have.descendants(ChildFixture)
 
 expect(wrapper).to.not.have.descendants('#root1')
 ```


### PR DESCRIPTION
Fix https://github.com/producthunt/chai-enzyme/issues/67