### PR TITLE
fix: ensure attributes with no value, or "slightly truthy values" pass .attr

### DIFF
--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -29,7 +29,9 @@ export default class ReactTestWrapper extends TestWrapper {
   }
 
   attr (name) {
-    return this.el.getAttribute(name) || undefined
+    if (this.el.hasAttribute(name)) {
+      return this.el.getAttribute(name) || ''
+    }
   }
 
   html () {

--- a/test/attr.test.js
+++ b/test/attr.test.js
@@ -1,10 +1,21 @@
+const magicToStringObject = {
+  toString () {
+    return 'magic'
+  }
+}
+
 class Fixture extends React.Component {
   render () {
+    /* eslint-disable react/jsx-boolean-value */
     return (
       <div id='root'>
         <span id='child'>test</span>
+        <video itemScope allowFullScreen={true} autoPlay={''} hidden={false} controls={null} loop={undefined}>test2</video>
+        <audio role name={''} accessKey={false} spellCheck={null} rel={magicToStringObject}>test3</audio>
+        <tr rowSpan={0} rows={0} cols={'4'} size={'0'}></tr>
       </div>
     )
+    /* eslint-enable react/jsx-boolean-value */
   }
 }
 
@@ -28,6 +39,68 @@ describe('#attr', () => {
     it('passes negated when the actual does not match the expected', (wrapper) => {
       expect(wrapper).to.not.have.attr('disabled')
       expect(wrapper.find('span')).to.not.have.attr('disabled')
+    })
+
+    describe('HAS_NUMERIC_VALUE attrs', () => {
+      it('passes when attribute exists without a `0` vaue', (wrapper) => {
+        expect(wrapper.find('tr')).to.have.attr('rowspan')
+      })
+    })
+
+    describe('HAS_POSITIVE_NUMERIC_VALUE attrs', () => {
+      it('passes when attribute exists with a string value', (wrapper) => {
+        expect(wrapper.find('tr')).to.have.attr('cols')
+      })
+
+      it('passes negated when attribute exists but has value `0`', (wrapper) => {
+        expect(wrapper.find('tr')).to.not.have.attr('rows')
+      })
+
+      it('passes negated when attribute exists but has value `"0"`', (wrapper) => {
+        expect(wrapper.find('tr')).to.not.have.attr('size')
+      })
+    })
+
+    describe('HAS_BOOLEAN_VALUE attrs', () => {
+      it('passes when attribute exists without a value', (wrapper) => {
+        expect(wrapper.find('video')).to.have.attr('itemscope')
+      })
+
+      it('passes negated when attribute exists with a falsey (but not false/null/undefined) value', (wrapper) => {
+        expect(wrapper.find('video')).to.not.have.attr('autoplay')
+        expect(wrapper.find('video')).to.not.have.attr('autoPlay')
+      })
+
+      it('passes negated when attribute exists but has value `false`', (wrapper) => {
+        expect(wrapper.find('video')).to.not.have.attr('hidden')
+      })
+
+      it('passes negated when attribute exists but has value `null`', (wrapper) => {
+        expect(wrapper.find('video')).to.not.have.attr('controls')
+      })
+
+      it('passes negated when attribute exists but has value `undefined`', (wrapper) => {
+        expect(wrapper.find('video')).to.not.have.attr('loop')
+      })
+    })
+
+    describe('regular attrs', () => {
+      it('passes when attribute exists without a value', (wrapper) => {
+        expect(wrapper.find('audio')).to.have.attr('role')
+      })
+
+      it('passes when attribute exists with a falsey (but not false/null/undefined) value', (wrapper) => {
+        expect(wrapper.find('audio')).to.have.attr('name')
+      })
+
+      it('passes when attribute exists but has value `false`', (wrapper) => {
+        expect(wrapper.find('audio')).to.have.attr('accesskey')
+      })
+
+      it('passes negated when attribute exists but has value `null`', (wrapper) => {
+        expect(wrapper.find('audio')).to.not.have.attr('spellcheck')
+        expect(wrapper.find('audio')).to.not.have.attr('spellCheck')
+      })
     })
 
     it('fails when the actual does not match the expected', (wrapper) => {
@@ -60,6 +133,20 @@ describe('#attr', () => {
       expect(() => {
         expect(wrapper.find('span')).to.have.attr('id', 'invalid')
       }).to.throw("to have a 'id' attr")
+    })
+
+    describe('HAS_BOOLEAN_VALUE attrs', () => {
+      it('converts values to empty strings', (wrapper) => {
+        expect(wrapper.find('video')).to.have.attr('itemscope', '')
+        expect(wrapper.find('video')).to.have.attr('allowfullscreen', '')
+      })
+    })
+
+    describe('regular attrs', () => {
+      it('converts values to strings', (wrapper) => {
+        expect(wrapper.find('audio')).to.have.attr('accesskey', 'false')
+        expect(wrapper.find('audio')).to.have.attr('rel', 'magic')
+      })
     })
   })
 


### PR DESCRIPTION
This wraps the mount wrapper in a `hasAttribute` check and if the value is falsey, it returns
true anyway - this way JSX like `<div itemScope />` will return true to having the itemscope
attribute.

Fixes #47. Closes #66 (picks up from @tleunen's work and completes it per @ljharb's comments).

Ping for people involved in #47: @vesln @tleunen @ljharb 
Ping for people involved in #66: @vesln @tleunen @ljharb @ayrton 