### PR TITLE
Add `exactly()` to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     1. [`className(str)`](#classnamestr)
     1. [`contain(node)`](#containnode)
     1. [`descendants(selector)`](#descendantsselector)
+      1. [`exactly()`](#exactly)
     1. [`disabled()`](#disabled)
     1. [`blank()`](#blank)
     1. [`present()`](#present)


### PR DESCRIPTION
Because it's a chain that only works with `descendants`, I've indented it one more level. Let me know if you'd rather have it at the same level.