### PR TITLE
Add assertion for .type()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     1. [`selected()`](#selected)
     1. [`tagName(str)`](#tagnamestr)
     1. [`text(str)`](#textstr)
+    1. [`type(func)`](#typefunc)
     1. [`value(str)`](#valuestr)
     1. [`attr(key, [val])`](#attrkey-val)
     1. [`data(key, [val])`](#datakey-val)
@@ -608,6 +609,49 @@ expect(wrapper.find('#child')).to.not.have.text('Other text')
 expect(wrapper.find('#child')).to.not.include.text('Other text') // include is an alias of contain
 
 expect(wrapper.find('#child')).to.have.text().match(/Test/)
+```
+
+#### `type(func)`
+
+| render | mount | shallow |
+| -------|-------|-------- |
+| no     | no    | yes     |
+
+
+Assert that the given wrapper has a given type:
+
+```js
+import React from 'react'
+import {shallow} from 'enzyme'
+
+class Foo extends React.Component {
+  render () {
+    return (
+      <div>Foo</div>
+    )
+  }
+}
+
+class Bar extends React.Component {
+  render () {
+    return (
+      <div>Bar</div>
+    )
+  }
+}
+
+class Fixture extends React.Component {
+  render () {
+    return (
+      <Foo />
+    )
+  }
+}
+
+const wrapper = shallow(<Fixture />) // mount/render/shallow when applicable
+
+expect(wrapper).to.have.type(Foo)
+expect(wrapper).to.not.have.type(Bar)
 ```
 
 #### `value(str)`

--- a/src/CheerioTestWrapper.js
+++ b/src/CheerioTestWrapper.js
@@ -118,4 +118,8 @@ export default class CheerioTestWrapper extends TestWrapper {
   hasRef () {
     throw new Error('static rendering does not support refs')
   }
+
+  type () {
+    throw new Error('static rendering does not support `type`')
+  }
 }

--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -90,4 +90,8 @@ export default class ReactTestWrapper extends TestWrapper {
   hasRef (ref) {
     return !!this.wrapper.instance().refs[ref]
   }
+
+  type () {
+    throw new Error('full DOM rendering does not support `type` yet')
+  }
 }

--- a/src/ShallowTestWrapper.js
+++ b/src/ShallowTestWrapper.js
@@ -95,4 +95,8 @@ export default class ShallowTestWrapper extends TestWrapper {
   hasRef () {
     throw new Error('shallow rendering does not support refs')
   }
+
+  type () {
+    return this.wrapper.type()
+  }
 }

--- a/src/assertions/type.js
+++ b/src/assertions/type.js
@@ -1,0 +1,11 @@
+export default function type ({wrapper, markup, arg1, sig}) {
+  const actual = wrapper.type()
+
+  this.assert(
+    actual === arg1,
+    () => `expected ${sig} to be of type #{exp}, but it is of type #{act} ${markup()}`,
+    () => `expected ${sig} to not be of type #{exp}, but it is of type #{act} ${markup()}`,
+    arg1,
+    actual
+  )
+}

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import ref from './assertions/ref'
 import selected from './assertions/selected'
 import tagName from './assertions/tagName'
 import text from './assertions/text'
+import type from './assertions/type'
 import value from './assertions/value'
 import exactly from './chains/exactly'
 import ChaiWrapper from './ChaiWrapper'
@@ -41,6 +42,7 @@ module.exports = function (debug = printDebug) {
     chaiWrapper.addAssertion(html, 'html')
     chaiWrapper.addAssertion(tagName, 'tagName')
     chaiWrapper.addAssertion(text, 'text')
+    chaiWrapper.addAssertion(type, 'type')
 
     chaiWrapper.overwriteProperty(empty, 'empty')
     chaiWrapper.addAssertion(empty, 'blank')

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -1,0 +1,49 @@
+class Foo extends React.Component {
+  render () {
+    return (
+      <div>Foo</div>
+    )
+  }
+}
+
+class Bar extends React.Component {
+  render () {
+    return (
+      <div>Bar</div>
+    )
+  }
+}
+
+class Fixture extends React.Component {
+  render () {
+    return (
+      <Foo />
+    )
+  }
+}
+
+const it = createTest(<Fixture />)
+
+describe('#type', () => {
+  describe('(type)', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper).to.have.type(Foo)
+    }, { render: false, mount: false })
+
+    it('passes negated when the actual does not match the expected', (wrapper) => {
+      expect(wrapper).to.not.have.type(Bar)
+    }, { render: false, mount: false })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper).to.have.type(Bar)
+      }).to.throw('to be of type [Function: Bar], but it is of type [Function: Foo]')
+    }, { render: false, mount: false })
+
+    it('fails when the actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.have.type(Foo)
+      }).to.throw()
+    }, { render: false, mount: false })
+  })
+})


### PR DESCRIPTION
Hi everyone,

I have a lot of tests that use shallow rendering to assert that a particular component renders another component as its child.  Normally, the assertions would look something like this:

``` js
//components
class Foo extends React.Component {
  render () {
    return (
      <Bar />
    )
  }
}

class Bar extends React.Component {
  render () {
    return (
      <div>Bar</div>
    )
  }
}

//tests
const shallowWrapper = shallow(<Foo />);

expect(shallowWrapper.type()).to.equal(Bar);
```

But I thought it would be nice to do something like this instead:

``` js
expect(shallowWrapper).to.have.type(Bar);
```

So this PR was born!

A side note: While I was working on this, I realized that the API for `.type()` works differently between [ShallowWrapper](https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/type.md) and [ReactWrapper](https://github.com/airbnb/enzyme/blob/master/docs/api/ReactWrapper/type.md)

``` js
const shallowWrapper = shallow(<Foo />);
console.log(shallowWrapper.type()); // [Function: Bar]

const reactWrapper = mount(<Foo />);
console.log(reactWrapper.type()); // [Function: Foo]
```

Because of this, I really wasn't sure how to go about supporting both `shallow()` and `mount()`, so I opted to only support what I needed.  If anyone has any input on how to get this behavior consistent between the two APIs, I'd be happy to try and implement it.

Thanks!
