### PR TITLE
Allow tests to run in more browsers by avoiding use of String.prototype.includes

### DIFF
--- a/src/assertions/text.js
+++ b/src/assertions/text.js
@@ -4,7 +4,7 @@ export default function text ({ wrapper, markup, flag, arg1, sig }) {
   if (undefined !== arg1) {
     if (flag(this, 'contains')) {
       this.assert(
-        actual.includes(String(arg1)),
+        actual.indexOf(String(arg1)) > -1,
         () => 'expected ' + sig + ' to contain text #{exp}, but it has #{act} ' + markup(),
         () => 'expected ' + sig + ' not to contain text #{exp}, but it has #{act} ' + markup(),
         arg1,


### PR DESCRIPTION
The `String.prototype.includes` method is [not available in all browsers](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility) which causes errors when using the following test construct: 
```
expect(wrapper).to.contain.text("foo bar")
```
Instead we could use the well-supported `String.prototype.indexOf` method which is used in the [`chai` library itself](https://github.com/chaijs/chai/blob/master/lib/chai/core/assertions.js#L325).

Our current workaround is to use the following construct
```
expect(wrapper.text()).to.contain("foo bar")
```
but it would be great to get this fixed here too.