### PR TITLE
Fix: use enzyme `is` for `match` assertion

### DIFF
--- a/src/ShallowTestWrapper.js
+++ b/src/ShallowTestWrapper.js
@@ -73,11 +73,11 @@ export default class ShallowTestWrapper extends TestWrapper {
   }
 
   isChecked () {
-    return this.is(':checked')
+    return this.el.is(':checked')
   }
 
   isDisabled () {
-    return this.is(':disabled')
+    return this.el.is(':disabled')
   }
 
   isSelected () {
@@ -85,7 +85,7 @@ export default class ShallowTestWrapper extends TestWrapper {
   }
 
   is (selector) {
-    return this.el.is(selector)
+    return this.wrapper.is(selector)
   }
 
   hasNode (node) {

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -1,8 +1,15 @@
+class MyComponent extends React.Component {
+  render () {
+    return <div />
+  }
+}
+
 class Fixture extends React.Component {
   render () {
     return (
       <div id='root'>
         <span id='child'>test</span>
+        <MyComponent id='my-component' />
       </div>
     )
   }
@@ -39,5 +46,27 @@ describe('#match', () => {
         expect(wrapper.find('span')).to.not.match('#child')
       }).to.throw("not to match '#child'")
     })
+  })
+
+  describe('(EnzymeSelector)', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper.find(MyComponent)).to.match('MyComponent')
+      expect(wrapper.find(MyComponent)).to.match(MyComponent)
+    }, { render: false })
+
+    it('passes negated when the actual does not match the expected', (wrapper) => {
+      expect(wrapper.find('#root')).to.not.match('MyComponent')
+      expect(wrapper.find('#root')).to.not.match(MyComponent)
+    }, { render: false })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper.find('#root')).to.match('MyComponent')
+      }).to.throw("to match 'MyComponent'")
+
+      expect(() => {
+        expect(wrapper.find('#root')).to.match(MyComponent)
+      }).to.throw('to match [Function: MyComponent]')
+    }, { render: false })
   })
 })


### PR DESCRIPTION
Using the `match` assertion appears to be deferring to the `is` function, which takes any valid EnzymeSelector (see https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/is.md).

However, when passing a react component by class object (not string) the matcher fails. This is because the `is` matcher for the ShallowTestWrapper is rendering the full HTML so it could also handle pseudo-classes (e.g. ':checked').

Given that EnzymeSelectors don't officially support psuedo-classes AND there are completely separate matchers for those already, I think it makes sense to make `match` directly use the default `is` function to be more consistent.

This change didn't break any specs, and I've added some new ones that were failing before the change.
