### PR TITLE
Document that style assertions should not be camelCased

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ const wrapper = mount(<Fixture />) // mount/render/shallow when applicable
 
 expect(wrapper).to.have.style('border')
 expect(wrapper).to.not.have.style('color')
+expect(wrapper).to.have.style('margin-top') // do not use camelCase keys as you would do in your React component
 
 expect(wrapper).to.have.style('border', '1px')
 expect(wrapper).to.not.have.style('border', '2px')


### PR DESCRIPTION
I got into the trap of thinking that `expect(wrapper).to.have.style('marginTop')` would work (because I did it this way in my component), but what actually works is using dashes, eg `margin-top`.

Therefore, I think others will benefit from this small documentation change!