### PR TITLE
Change exactlyCount check to type check fixes #141

### DIFF
--- a/src/assertions/descendants.js
+++ b/src/assertions/descendants.js
@@ -1,7 +1,7 @@
 export default function descendants ({ wrapper, markup, arg1, sig, flag }) {
   const exactlyCount = flag(this, 'exactlyCount')
 
-  if (exactlyCount) {
+  if (typeof exactlyCount === 'number') {
     const descendantCount = wrapper.getDescendantsCount(arg1)
 
     this.assert(


### PR DESCRIPTION
Without the type check ```expect(wrapper).to.have.exactly(0).descendants(selector);``` will not result as expected