### PR TITLE
handle `.exactly(0)`

### DIFF
--- a/src/assertions/descendants.js
+++ b/src/assertions/descendants.js
@@ -1,7 +1,7 @@
 export default function descendants ({ wrapper, markup, arg1, sig, flag }) {
   const exactlyCount = flag(this, 'exactlyCount')
 
-  if (exactlyCount) {
+  if (exactlyCount !== undefined) {
     const descendantCount = wrapper.getDescendantsCount(arg1)
 
     this.assert(

--- a/src/assertions/descendants.js
+++ b/src/assertions/descendants.js
@@ -1,7 +1,7 @@
 export default function descendants ({ wrapper, markup, arg1, sig, flag }) {
   const exactlyCount = flag(this, 'exactlyCount')
 
-  if (exactlyCount !== undefined) {
+  if (exactlyCount || exactlyCount === 0) {
     const descendantCount = wrapper.getDescendantsCount(arg1)
 
     this.assert(

--- a/test/exactly.test.js
+++ b/test/exactly.test.js
@@ -20,7 +20,7 @@ class Fixture extends React.Component {
 
 const it = createTest(<Fixture />)
 
-describe.only('#exactly', () => {
+describe('#exactly', () => {
   describe('descendants', () => {
     it('passes when the actual matches the expected', (wrapper) => {
       expect(wrapper).to.have.descendants('#root')

--- a/test/exactly.test.js
+++ b/test/exactly.test.js
@@ -20,13 +20,17 @@ class Fixture extends React.Component {
 
 const it = createTest(<Fixture />)
 
-describe('#exactly', () => {
+describe.only('#exactly', () => {
   describe('descendants', () => {
     it('passes when the actual matches the expected', (wrapper) => {
       expect(wrapper).to.have.descendants('#root')
       expect(wrapper.find('#child')).to.have.descendants('#last')
       expect(wrapper).to.not.have.exactly(2).descendants('.multiple')
       expect(wrapper).to.have.exactly(8).descendants('.multiple')
+    })
+
+    it('passes when the the expected is 0 and there are none', (wrapper) => {
+      expect(wrapper).to.have.exactly(0).descendants('#root1')
     })
 
     it('passes negated when the actual does not match the expected', (wrapper) => {
@@ -46,6 +50,12 @@ describe('#exactly', () => {
       expect(() => {
         expect(wrapper).to.not.have.exactly(8).descendants('.multiple')
       }).to.throw("not to have 8 descendants '.multiple'")
+    })
+
+    it('fails when the the expected is 0 and there are some', (wrapper) => {
+      expect(() => {
+        expect(wrapper).to.have.exactly(0).descendants('#root')
+      }).to.throw("to have 0 descendants '#root'")
     })
   })
 })


### PR DESCRIPTION
This is a minor item, but I noticed that if I had a test use the chain `expect(wrapper).to.have.exactly(0).descendants("foo")` it was being treated as if it was `expect(wrapper).to.have.descendants("foo")`.

Obviously the workaround is to use `.to.not.have.descendants(...)` but I figured it was worth fixing.