### PR TITLE
Fix 0.7.0 regression when plugin is included twice

### DIFF
--- a/src/ChaiWrapper.js
+++ b/src/ChaiWrapper.js
@@ -104,15 +104,26 @@ export default class ChaiWrapper {
         return _super.apply(this, arguments)
       }
 
-      assertion.call(this, {
+      const config = {
         markup: () => debug(wrapper),
         sig: inspect(wrapper),
         wrapper,
         arg1,
-        arg2,
         flag,
         inspect
-      })
+      }
+
+      /**
+       * Checking the length of the arguments array to make
+       * sure that we have a defined argument assigned to arg2.
+       * By default, 'undefined' is assigned to arg2 if no specific arguments exist...
+       *
+       */
+      if (arguments.length > 1) {
+        config.arg2 = arg2
+      }
+
+      assertion.call(this, config)
     }
   }
 


### PR DESCRIPTION
This is an alternative to #181 that also fixes #180. It does so by somehow changing the wrapper setups so that the wrapped methods don't end up with arity of 2 when they were originally 1.

I'm not sure of all the inner workings to understand why when the plugin is included twice, these wrapper methods are applied in such a way that causes this outcome, but this does fix the issue and can be confirmed by [updating the `helpers.js` to include the plugin twice](https://github.com/producthunt/chai-enzyme/blob/6e08db5215eb3a35ff94118e25b804123b9e38a4/test/support/helper.js#L17).

I would prefer that this PR be rejected in favor of #181, though.