### PR TITLE
Allow for newer versions of chai and cheerio.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,10 @@ node_js:
   - "4.2"
   - "4.1"
   - "4.0"
+env:
+  - CHAI_VERSION=^3.0.0
+  - CHAI_VERSION=^4.0.0
+before_script:
+  - npm install chai@$CHAI_VERSION
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test": "npm run test:lint && npm run test:unit"
   },
   "peerDependencies": {
-    "chai": "3.x",
-    "cheerio": "0.19.x || 0.20.x || 0.22.x",
+    "chai": "^3.0.0 || ^4.0.0",
+    "cheerio": "0.19.x || 0.20.x || 0.22.x || 1.0.0-rc.1",
     "enzyme": "1.x || ^2.3.0",
     "react": "^0.14.0 || ^15.0.0-0",
     "react-dom": "^0.14.0 || ^15.0.0-0"
@@ -56,7 +56,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.5.2",
-    "chai": "^3.5.0",
+    "chai": "^4.0.2",
     "cross-env": "3.1.4",
     "enzyme": "^2.3.0",
     "jsdom": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.5.2",
-    "chai": "^4.0.2",
+    "chai": "^3.0.0 || ^4.0.0",
     "cross-env": "3.1.4",
     "enzyme": "^2.3.0",
     "jsdom": "^9.1.0",


### PR DESCRIPTION
Ideally, you would want to run a test harness for both versions if you plan on supporting 3.x for a while.