### PR TITLE
Support an array of nodes in `contain`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   1. [Assertions](#assertions)
     1. [`checked()`](#checked)
     1. [`className(str)`](#classnamestr)
-    1. [`contain(node)`](#containnode)
+    1. [`contain(nodeOrNodes)`](#containnodeornodes)
     1. [`containMatchingElement(node)`](#containmatchingelementnode)
     1. [`descendants(selector)`](#descendantsselector)
       1. [`exactly()`](#exactly)
@@ -173,14 +173,14 @@ expect(wrapper.find('span')).to.have.className('child')
 expect(wrapper.find('span')).to.not.have.className('root')
 ```
 
-#### `contain(node)`
+#### `contain(nodeOrNodes)`
 
 | render | mount | shallow |
 | -------|-------|-------- |
 | no     | yes   | yes     |
 
 
-Assert that the wrapper contains a given node:
+Assert that the wrapper contains a given node or array of nodes:
 
 ```js
 import React from 'react'
@@ -205,7 +205,10 @@ class Fixture extends React.Component {
       <div>
         <ul>
           <li><User index={1} /></li>
-          <li><User index={2} /></li>
+          <li>
+            <User index={2} />
+            <User index={3} />
+          </li>
         </ul>
       </div>
     )
@@ -215,6 +218,7 @@ class Fixture extends React.Component {
 const wrapper = mount(<Fixture />) // mount/render/shallow when applicable
 
 expect(wrapper).to.contain(<User index={1} />)
+expect(wrapper).to.contain([<User index={2} />, <User index={3} />])
 expect(wrapper).to.not.contain(<User index={3} />)
 ```
 

--- a/src/assertions/contain.js
+++ b/src/assertions/contain.js
@@ -1,7 +1,7 @@
-import reactElementToJSXString from 'react-element-to-jsx-string'
+import reactNodeToString from '../reactNodeToString'
 
 export default function contain ({ wrapper, markup, arg1, sig }) {
-  const arg1JSXString = reactElementToJSXString(arg1)
+  const arg1JSXString = reactNodeToString(arg1)
 
   this.assert(
     wrapper.hasNode(arg1),

--- a/src/reactNodeToString.js
+++ b/src/reactNodeToString.js
@@ -1,0 +1,20 @@
+import reactElementToJSXString from 'react-element-to-jsx-string'
+
+function reactArrayToJSXString (nodes) {
+  let jsxString = '['
+  nodes.forEach((node, idx) => {
+    jsxString += `\n  ${reactElementToJSXString(node)}`
+    if (idx < nodes.length - 1) {
+      jsxString += ','
+    }
+  })
+  return `${jsxString}\n]`
+}
+
+export default function reactNodeToString (node) {
+  if (Array.isArray(node)) {
+    return reactArrayToJSXString(node)
+  } else {
+    return reactElementToJSXString(node)
+  }
+}

--- a/test/contain.test.js
+++ b/test/contain.test.js
@@ -18,7 +18,10 @@ class Fixture extends React.Component {
       <div>
         <ul>
           <li><User index={1} /></li>
-          <li><User index={2} /></li>
+          <li>
+            <User index={2} />
+            <User index={3} />
+          </li>
         </ul>
       </div>
     )
@@ -35,13 +38,13 @@ describe('#contain', () => {
     }, { render: false })
 
     it('passes negated when the actual does not match the expected', (wrapper) => {
-      expect(wrapper).to.not.contain(<User index={3} />)
+      expect(wrapper).to.not.contain(<User index={4} />)
     }, { render: false })
 
     it('fails when the actual does not match the expected', (wrapper) => {
       expect(() => {
-        expect(wrapper).to.contain(<User index={3} />)
-      }).to.throw('to contain <User index={3} />')
+        expect(wrapper).to.contain(<User index={4} />)
+      }).to.throw('to contain <User index={4} />')
 
       expect(() => {
         expect(wrapper).to.not.contain(<User index={2} />)
@@ -51,6 +54,32 @@ describe('#contain', () => {
     it('fails when the actual is undefined', () => {
       expect(() => {
         expect(undefined).to.contain(<User index={1} />)
+      }).to.throw()
+    })
+  })
+
+  describe('(nodes)', () => {
+    it('passes when the actual matches the expected', (wrapper) => {
+      expect(wrapper).to.contain([<User index={2} />, <User index={3} />])
+    }, { render: false })
+
+    it('passes negated when the actual does not match the expected', (wrapper) => {
+      expect(wrapper).to.not.contain([<User index={3} />, <User index={4} />])
+    }, { render: false })
+
+    it('fails when the actual does not match the expected', (wrapper) => {
+      expect(() => {
+        expect(wrapper).to.contain([<User index={3} />, <User index={4} />])
+      }).to.throw('to contain [\n  <User index={3} />,\n  <User index={4} />\n]')
+
+      expect(() => {
+        expect(wrapper).to.not.contain([<User index={2} />, <User index={3} />])
+      }).to.throw('not to contain [\n  <User index={2} />,\n  <User index={3} />\n]')
+    }, { render: false })
+
+    it('fails when the actual is undefined', () => {
+      expect(() => {
+        expect(undefined).to.contain([<User index={2} />, <User index={3} />])
       }).to.throw()
     })
   })


### PR DESCRIPTION
The enzyme [`contains` assertion](https://github.com/airbnb/enzyme/blob/master/docs/api/ReactWrapper/contains.md) accepts a node or an array of nodes as an argument. The current use of `react-element-to-jsx-string` prevents this from working in chai-enzyme. This PR allows the passing of an array of nodes and updates the documentation.