### PR TITLE
Make compatible with enzyme v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "build": "babel src --out-dir build",
     "clean": "rimraf build",
     "test:lint": "standard --verbose | snazzy",
-    "test:unit": "cross-env NODE_ENV=test mocha test/**/*.test.js",
+    "test:unit": "cross-env NODE_ENV=test mocha --require test/enzyme-preamble.js test/**/*.test.js",
     "test:watch": "npm run test:unit -- --watch",
     "test": "npm run test:lint && npm run test:unit"
   },
   "peerDependencies": {
     "chai": "^3.0.0 || ^4.0.0",
-    "cheerio": "0.19.x || 0.20.x || 0.22.x || 1.0.0-rc.1",
-    "enzyme": "1.x || ^2.3.0",
-    "react": "^0.14.0 || ^15.0.0-0",
-    "react-dom": "^0.14.0 || ^15.0.0-0"
+    "cheerio": "0.19.x || 0.20.x || 0.22.x || ^1.0.0-0",
+    "enzyme": "^2.7.0 || ^3.0.0-0",
+    "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
+    "react-dom": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0"
   },
   "keywords": [
     "javascript",
@@ -58,13 +58,15 @@
     "babel-register": "^6.5.2",
     "chai": "^3.0.0 || ^4.0.0",
     "cross-env": "3.1.4",
-    "enzyme": "^2.3.0",
+    "enzyme": "^3.0.0-beta.5",
+    "enzyme-adapter-react-15": "^1.0.0-beta.5",
     "jsdom": "^9.1.0",
     "mocha": "^3.0.0",
     "prop-types": "^15.5.7",
-    "react": "^0.14.0 || ^15.0.0-0",
-    "react-addons-test-utils": "^0.14.0 || ^15.0.0-0",
-    "react-dom": "^0.14.0 || ^15.0.0-0",
+    "raf": "^3.3.2",
+    "react": "^15.6.0",
+    "react-dom": "^15.6.0",
+    "react-test-renderer": "^15.6.0",
     "rimraf": "^2.5.0",
     "snazzy": "^5.0.0",
     "standard": "^8.1.0"
@@ -84,7 +86,8 @@
     ]
   },
   "dependencies": {
+    "create-react-class": "^15.6.0",
     "html": "^1.0.0",
-    "react-element-to-jsx-string": "^5.0.0"
+    "react-element-to-jsx-string": "^12.0.0"
   }
 }

--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -1,6 +1,12 @@
-import {findDOMNode} from 'enzyme/build/react-compat'
-
 import TestWrapper from './TestWrapper'
+
+function getRoot (wrapper) {
+  // doing this to maintain backwards compatibility with enzyme 2.x
+  if (typeof wrapper.root === 'function') {
+    return wrapper.root()
+  }
+  return wrapper.root
+}
 
 export default class ReactTestWrapper extends TestWrapper {
   constructor (wrapper) {
@@ -10,18 +16,16 @@ export default class ReactTestWrapper extends TestWrapper {
 
   get el () {
     if (!this.__el) {
-      this.__el = this.wrapper.single((n) => findDOMNode(n))
+      this.__el = this.wrapper.getDOMNode()
     }
 
     return this.__el
   }
 
   inspect () {
-    const name = this.wrapper.root.node.constructor.displayName ||
-      this.wrapper.root.node.constructor.name ||
-      '???'
+    const name = getRoot(this.wrapper).name() || '???'
 
-    if (this.wrapper.root === this.wrapper) {
+    if (getRoot(this.wrapper) === this.wrapper) {
       return `<${name} />`
     }
 

--- a/src/ShallowTestWrapper.js
+++ b/src/ShallowTestWrapper.js
@@ -2,6 +2,22 @@ import $ from 'cheerio'
 
 import TestWrapper from './TestWrapper'
 
+function getRoot (wrapper) {
+  // doing this to maintain backwards compatibility with enzyme 2.x
+  if (typeof wrapper.root === 'function') {
+    return wrapper.root()
+  }
+  return wrapper.root
+}
+
+function getRootName (wrapper) {
+  const root = getRoot(wrapper)
+  const instance = root.instance()
+  const fn = instance && instance.constructor
+  const name = fn ? fn.displayName || fn.name : root.name();
+  return name || '???'
+}
+
 export default class ShallowTestWrapper extends TestWrapper {
   constructor (wrapper) {
     super()
@@ -17,11 +33,9 @@ export default class ShallowTestWrapper extends TestWrapper {
   }
 
   inspect () {
-    const name = this.wrapper.root.unrendered.type.displayName ||
-      this.wrapper.root.unrendered.type.name ||
-      '???'
+    const name = getRootName(this.wrapper)
 
-    if (this.wrapper.root === this.wrapper) {
+    if (getRoot(this.wrapper) === this.wrapper) {
       return `<${name} />`
     }
 

--- a/test/enzyme-preamble.js
+++ b/test/enzyme-preamble.js
@@ -1,0 +1,6 @@
+require('raf/polyfill')
+
+const Enzyme = require('enzyme')
+const Adapter = require('enzyme-adapter-react-15')
+
+Enzyme.configure({ adapter: new Adapter() })

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -1,3 +1,4 @@
+import createReactClass from 'create-react-class'
 import {shallow, render, mount} from 'enzyme'
 import wrap from '../src/wrap'
 
@@ -9,7 +10,7 @@ class ClassSyntax extends React.Component {
   }
 }
 
-const DisplayNameSyntax = React.createClass({
+const DisplayNameSyntax = createReactClass({
   displayName: 'DisplayNameSyntax',
 
   render () {


### PR DESCRIPTION
to: @ayrton

This PR updates chai-enzyme to be compatible with the soon-to-be-released Enzyme 3.0. There were a couple of things being used in chai-enzyme that were "private" from enzyme, but you can use public APIs to achieve the same result. Most everything else should not break any of chai-enzyme's functionality.

The one caveat is that enzyme v3 pulls in the new 1.x version of cheerio, which appears to break a handful of the render tests in this repo.  I don't have a ton of context around 1) what changed in cheerio from 0.x => 1.x and 2) how chai and this repo really work, so I was really struggling on getting these tests to pass. I was hoping I could get a bit of guidance here.