### PR TITLE
increase performance of contain and containMatchingElement

### DIFF
--- a/src/assertions/contain.js
+++ b/src/assertions/contain.js
@@ -1,12 +1,10 @@
 import reactNodeToString from '../reactNodeToString'
 
 export default function contain ({ wrapper, markup, arg1, sig }) {
-  const arg1JSXString = reactNodeToString(arg1)
-
   this.assert(
     wrapper.hasNode(arg1),
-    () => 'expected ' + sig + ' to contain ' + arg1JSXString + markup(),
-    () => 'expected ' + sig + ' not to contain ' + arg1JSXString + markup(),
+    () => 'expected ' + sig + ' to contain ' + reactNodeToString(arg1) + markup(),
+    () => 'expected ' + sig + ' not to contain ' + reactNodeToString(arg1) + markup(),
     arg1
   )
 }

--- a/src/assertions/containMatchingElement.js
+++ b/src/assertions/containMatchingElement.js
@@ -1,12 +1,10 @@
 import reactNodeToString from '../reactNodeToString'
 
 export default function containMatchingElement ({ wrapper, markup, arg1, sig }) {
-  const arg1JSXString = reactNodeToString(arg1)
-
   this.assert(
     wrapper.wrapper.containsMatchingElement(arg1),
-    () => 'expected ' + sig + ' to contain matching ' + arg1JSXString + markup(),
-    () => 'expected ' + sig + ' not to contain matching ' + arg1JSXString + markup(),
+    () => 'expected ' + sig + ' to contain matching ' + reactNodeToString(arg1) + markup(),
+    () => 'expected ' + sig + ' not to contain matching ' + reactNodeToString(arg1) + markup(),
     arg1
   )
 }


### PR DESCRIPTION
before, reactNodeToString was called no matter what. With this
change, it will only be called when the assert fails.