### PR TITLE
Explicitly reference className prop due to SVGAnimatedString className

### DIFF
--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -53,6 +53,9 @@ export default class ReactTestWrapper extends TestWrapper {
   }
 
   classNames () {
+    if (this.tagName() === 'svg') {
+      return this.attr('class')
+    }
     return this.el.className
   }
 


### PR DESCRIPTION
[As noted on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/className#notes), the value of `el.className` might not be as expected when `el` is an `SVGElement`.  Instead of the expected string, it can be an instance of `SVGAnimatedString`.

When this is the case, tests fail with the following error:
```js
TypeError: this.classNames(...).split is not a function
```

This PR instead returns the contents of the element's `class` attribute when the element tagName is  `svg`