### PR TITLE
Cannot convert a Symbol value to a string

### DIFF
--- a/src/ReactTestWrapper.js
+++ b/src/ReactTestWrapper.js
@@ -16,7 +16,7 @@ export default class ReactTestWrapper extends TestWrapper {
 
   inspect () {
     const root = this.root()
-    const name = root.name() || '???'
+    const name = String(root.name() || '???')
 
     if (root === this.wrapper) {
       return `<${name} />`

--- a/src/ShallowTestWrapper.js
+++ b/src/ShallowTestWrapper.js
@@ -23,7 +23,7 @@ export default class ShallowTestWrapper extends TestWrapper {
 
     const rootInstance = root.instance()
     const rootType = rootInstance && rootInstance.constructor
-    const name = rootType ? getDisplayName(rootType) : (root.name() || '???')
+    const name = String(rootType ? getDisplayName(rootType) : (root.name() || '???'))
 
     if (root === this.wrapper) {
       return `<${name} />`

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -19,6 +19,13 @@ const DisplayNameSyntax = class extends React.Component {
 
 DisplayNameSyntax.displayName = 'DisplayNameSyntax'
 
+const SymbolComponent = class extends React.Component {
+  render () {
+    return (<div />)
+  }
+}
+SymbolComponent.displayName = Symbol('SymbolComponent')
+
 function inspect (wrapper) {
   return wrap(wrapper).inspect()
 }
@@ -31,6 +38,8 @@ describe('#inspect', () => {
       expect(String(inspect(shallow(<DisplayNameSyntax />).find('div')))).to.equal('the node in <DisplayNameSyntax />')
       expect(String(inspect(shallow(<DisplayNameSyntax />).find('span')))).to.equal('the node in <DisplayNameSyntax />')
       expect(String(inspect(shallow(<div />)))).to.equal('<div />')
+      expect(String(inspect(shallow(<SymbolComponent />)))).to.equal(`<${String(SymbolComponent.displayName)} />`)
+      expect(String(inspect(shallow(<SymbolComponent />).find('div')))).to.equal(`the node in <${String(SymbolComponent.displayName)} />`)
     })
   })
 
@@ -40,6 +49,8 @@ describe('#inspect', () => {
       expect(String(inspect(mount(<DisplayNameSyntax />)))).to.equal('<DisplayNameSyntax />')
       expect(String(inspect(mount(<DisplayNameSyntax />).find('div')))).to.equal('the node in <DisplayNameSyntax />')
       expect(String(inspect(mount(<DisplayNameSyntax />).find('span')))).to.equal('the node in <DisplayNameSyntax />')
+      expect(String(inspect(mount(<SymbolComponent />)))).to.equal(`<${String(SymbolComponent.displayName)} />`)
+      expect(String(inspect(mount(<SymbolComponent />).find('div')))).to.equal(`the node in <${String(SymbolComponent.displayName)} />`)
     })
   })
 
@@ -47,6 +58,7 @@ describe('#inspect', () => {
     it('returns unknown', () => {
       expect(String(inspect(render(<ClassSyntax />)))).to.equal('the node in <??? />')
       expect(String(inspect(render(<DisplayNameSyntax />)))).to.equal('the node in <??? />')
+      expect(String(inspect(render(<SymbolComponent />)))).to.equal(`the node in <??? />`)
     })
   })
 })


### PR DESCRIPTION
Always convert the name to string when in `ShallowTestWrapper#inspect` and `ReactTestWrapper#inspect` so it still works for components that have a `Symbol` as a `displayName`.

Since `name` is always gonna be defined I think it is fine to just call `.toString`, although some logic could be added to look for just `Symbol` instances.

https://github.com/producthunt/chai-enzyme/issues/214