### PR TITLE
shallow render error messages now only show components under test

### DIFF
--- a/src/ShallowTestWrapper.js
+++ b/src/ShallowTestWrapper.js
@@ -37,7 +37,7 @@ export default class ShallowTestWrapper extends TestWrapper {
   }
 
   html () {
-    return this.wrapper.html()
+    return this.wrapper.debug().replace(/\n(\s*)/g, '')
   }
 
   style (name) {

--- a/test/contain.test.js
+++ b/test/contain.test.js
@@ -87,8 +87,6 @@ describe('#contain', () => {
       expect(() => {
         expect(wrapper).to.contain([<User index={3} />, <User index={4} />])
       }).to.throw('<li>\n           <User index={1} />\n         </li>')
-
     }, { render: false, mount: false })
-
   })
 })

--- a/test/contain.test.js
+++ b/test/contain.test.js
@@ -82,5 +82,13 @@ describe('#contain', () => {
         expect(undefined).to.contain([<User index={2} />, <User index={3} />])
       }).to.throw()
     })
+
+    it('fails and shows one level deep', (wrapper) => {
+      expect(() => {
+        expect(wrapper).to.contain([<User index={3} />, <User index={4} />])
+      }).to.throw('<li>\n           <User index={1} />\n         </li>')
+
+    }, { render: false, mount: false })
+
   })
 })


### PR DESCRIPTION
(the first level components)

Fixes #218.